### PR TITLE
Increase raft store threads

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -275,10 +275,10 @@
 # cleanup-import-sst-interval = "10m"
 
 ## Use how many threads to handle log apply
-# apply-pool-size = 2
+# apply-pool-size = 4
 
 ## Use how many threads to handle raft messages
-# store-pool-size = 2
+# store-pool-size = 4
 
 [coprocessor]
 ## When it is set to `true`, TiKV will try to split a Region with table prefix if that Region

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -188,9 +188,10 @@ impl Default for Config {
             cleanup_import_sst_interval: ReadableDuration::minutes(10),
             local_read_batch_size: 1024,
             apply_max_batch_size: 1024,
-            apply_pool_size: 2,
+            // Hacked by JaySon-Huang, make apply_pool_size, store_pool_size 4 by default.
+            apply_pool_size: 4,
             store_max_batch_size: 1024,
-            store_pool_size: 2,
+            store_pool_size: 4,
             future_poll_size: 1,
             hibernate_regions: false,
 


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <tshent@qq.com>

Increase raft.apply-pool-size and raft.store-pool-size to 4. Make it better for high update workload.