### PR TITLE
Report store written bytes and written keys

### DIFF
--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -655,17 +655,21 @@ where
     }
 
     fn handle_store_heartbeat(&mut self, mut stats: pdpb::StoreStats, store_info: StoreInfo<EK>) {
-        let fs_stats = get_tiflash_server_helper().handle_compute_fs_stats();
-        if fs_stats.ok == 0 {
+        let store_stats = get_tiflash_server_helper().handle_compute_store_stats();
+        if store_stats.fs_stats.ok == 0 {
             return;
         }
-        let capacity = fs_stats.capacity_size;
-        let available = fs_stats.avail_size;
-        stats.set_used_size(fs_stats.used_size);
+        let capacity = store_stats.fs_stats.capacity_size;
+        let available = store_stats.fs_stats.avail_size;
+        stats.set_used_size(store_stats.fs_stats.used_size);
         stats.set_capacity(capacity);
         stats.set_available(available);
+        // report `bytes_written`, `keys_written`, `bytes_read`, `keys_read` to PD
+        stats.set_bytes_written(store_stats.engine_bytes_written);
+        stats.set_keys_written(store_stats.engine_keys_written);
+        stats.set_bytes_read(store_stats.engine_bytes_read);
+        stats.set_bytes_read(store_stats.engine_keys_read);
 
-        // TODO: report `bytes_written`, `keys_written`, `bytes_read`, `keys_read` to PD
 
         let mut interval = pdpb::TimeInterval::default();
         interval.set_start_timestamp(self.store_stat.last_report_ts.into_inner());

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -664,12 +664,10 @@ where
         stats.set_used_size(store_stats.fs_stats.used_size);
         stats.set_capacity(capacity);
         stats.set_available(available);
-        // report `bytes_written`, `keys_written`, `bytes_read`, `keys_read` to PD
         stats.set_bytes_written(store_stats.engine_bytes_written);
         stats.set_keys_written(store_stats.engine_keys_written);
         stats.set_bytes_read(store_stats.engine_bytes_read);
-        stats.set_bytes_read(store_stats.engine_keys_read);
-
+        stats.set_keys_read(store_stats.engine_keys_read);
 
         let mut interval = pdpb::TimeInterval::default();
         interval.set_start_timestamp(self.store_stat.last_report_ts.into_inner());

--- a/components/raftstore/src/tiflash_ffi/mod.rs
+++ b/components/raftstore/src/tiflash_ffi/mod.rs
@@ -581,6 +581,15 @@ pub struct FsStats {
 }
 
 #[repr(C)]
+pub struct StoreStats {
+    pub fs_stats: FsStats,
+    pub engine_bytes_written: u64,
+    pub engine_keys_written: u64,
+    pub engine_bytes_read: u64,
+    pub engine_keys_read: u64,
+}
+
+#[repr(C)]
 pub struct CppStrWithView {
     inner: RawCppPtr,
     pub view: BaseBuffView,
@@ -629,7 +638,7 @@ pub struct TiFlashServerHelper {
     handle_destroy: extern "C" fn(TiFlashServerPtr, RegionId),
     handle_ingest_sst: extern "C" fn(TiFlashServerPtr, SnapshotViewArray, RaftCmdHeader) -> u32,
     handle_check_terminated: extern "C" fn(TiFlashServerPtr) -> u8,
-    handle_compute_fs_stats: extern "C" fn(TiFlashServerPtr) -> FsStats,
+    handle_compute_store_stats: extern "C" fn(TiFlashServerPtr) -> StoreStats,
     handle_get_tiflash_status: extern "C" fn(TiFlashServerPtr) -> u8,
     pre_handle_snapshot: extern "C" fn(
         TiFlashServerPtr,
@@ -681,8 +690,8 @@ impl TiFlashServerHelper {
         (self.handle_get_table_sync_status)(self.inner, table_id)
     }
 
-    pub fn handle_compute_fs_stats(&self) -> FsStats {
-        (self.handle_compute_fs_stats)(self.inner)
+    pub fn handle_compute_store_stats(&self) -> StoreStats {
+        (self.handle_compute_store_stats)(self.inner)
     }
 
     pub fn handle_write_raft_cmd(
@@ -705,7 +714,7 @@ impl TiFlashServerHelper {
     pub fn check(&self) {
         assert_eq!(std::mem::align_of::<Self>(), std::mem::align_of::<u64>());
         const MAGIC_NUMBER: u32 = 0x13579BDF;
-        const VERSION: u32 = 401002;
+        const VERSION: u32 = 401003;
 
         if self.magic_number != MAGIC_NUMBER {
             eprintln!(


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <tshent@qq.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: related to https://github.com/pingcap/tics/issues/1235

Problem Summary:
TiFlash does not report the written bytes nor written keys to PD

### What is changed and how it works?

Change the FFI function from `handle_compute_fs_stats: extern "C" fn(TiFlashServerPtr) -> FsStats` to `handle_compute_store_stats: extern "C" fn(TiFlashServerPtr) -> StoreStats` and report more stats to PD

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Side effects

- N/A

### Release note <!-- bugfixes or new feature need a release note -->