### PR TITLE
Keep the behavior of report 0 written bytes and keys to PD for release-4.0 branch

### DIFF
--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -616,6 +616,10 @@ impl<T: PdClient> Runner<T> {
         stats.set_available(available);
 
         // TODO: report `bytes_written`, `keys_written`, `bytes_read`, `keys_read` to PD
+        stats.clear_bytes_written();
+        stats.clear_keys_written();
+        stats.clear_bytes_read();
+        stats.clear_keys_read();
 
         let mut interval = pdpb::TimeInterval::default();
         interval.set_start_timestamp(self.store_stat.last_report_ts.into_inner());


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <tshent@qq.com>


### What problem does this PR solve?

Issue Number: related to https://github.com/pingcap/tics/issues/1235

In this commit https://github.com/solotzg/tikv/commit/29ebdc0b475b0e0cb66eca1e47d560ed7fb286bf, update the written metrics. But the written keys and bytes reported are very different from that in the TiKV store.

Before we verify the move-hot-region feature with PD, we'd better keep the same behavior with the version earlier than v4.0.9.

Here is a screenshot with only one v4.0.8 TiKV store and one v4.0.9 TiFlash store (with proxy commit c2f36e2)
<img width="2490" alt="WeChatWorkScreenshot_02d32126-3327-450e-bb3f-f7f8e9eed4bb" src="https://user-images.githubusercontent.com/4865550/101624597-1b533080-3a55-11eb-9048-e7bc38b3c891.png">

### What is changed and how it works?

Keep the bytes_written / keys_written reported to PD to be 0.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->